### PR TITLE
Fix variable name changes due to site update (solves 99 attack and teamwork issue)

### DIFF
--- a/src/js/pes21_player.js
+++ b/src/js/pes21_player.js
@@ -480,11 +480,11 @@ False;\
     this.weakFootUsage = this.weakFootAccuracy > 1 ? this.weakFootAccuracy - 1 : this.weakFootAccuracy;
 
     //field players
-    this.offensiveAwareness = this.ConvertFIFAStatToPES21(fifaPlayer.mentality["Att. Position"]);
-    if (fifaPlayer.mentality["Att. Position"] < fifaPlayer.movement["Reactions"]) {
+    this.offensiveAwareness = this.ConvertFIFAStatToPES21(fifaPlayer.mentality["Attack position"]);
+    if (fifaPlayer.mentality["Attck position"] < fifaPlayer.movement["Reactions"]) {
       this.offensiveAwareness++;
     }
-    else if (fifaPlayer.mentality["Att. Position"] > fifaPlayer.movement["Reactions"]) {
+    else if (fifaPlayer.mentality["Attack position"] > fifaPlayer.movement["Reactions"]) {
       this.offensiveAwareness--;
     }
     this.ballControl = this.ConvertFIFAStatToPES21(fifaPlayer.skill["Ball control"]);

--- a/src/js/pes_player.js
+++ b/src/js/pes_player.js
@@ -321,7 +321,7 @@ ${clamp(40, 123, this.weight)}`;
 
     if (this.registeredPosition == "GK") {
       //convertion formula for GK
-      let positioning = MinorThan(fifaPlayer.mentality["Att. Position"], 30);
+      let positioning = MinorThan(fifaPlayer.mentality["Attack position"], 30);
       let attackEXP = positioning;
       this.attack = 10 + DivideIntegers(attackEXP, this.EXP_ID_Value);
 
@@ -429,7 +429,7 @@ ${clamp(40, 123, this.weight)}`;
     else {
       // rest of players
 
-      let positioning = fifaPlayer.mentality["Att. Position"];
+      let positioning = fifaPlayer.mentality["Attack position"];
       let attackExtraPoints = 25;
       if (this.registeredPosition == "CBT") {
         attackExtraPoints = 20;
@@ -578,7 +578,7 @@ ${clamp(40, 123, this.weight)}`;
       this.tacticalDribble = 0;
     }
 
-    if (fifaPlayer.mentality["Att. Position"] > 85 &&
+    if (fifaPlayer.mentality["Attack position"] > 85 &&
       hasSpecialAbility(this.positioningPositions, this.registeredPosition, this.positions)
     ) {
       this.positioning = 1;
@@ -674,7 +674,7 @@ ${clamp(40, 123, this.weight)}`;
 
     if (fifaPlayer.traits.includes("Playmaker (AI)") &&
       fifaPlayer.mentality["Vision"] > 80 &&
-      fifaPlayer.mentality["Att. Position"] > 80
+      fifaPlayer.mentality["Attack position"] > 80
     ) {
       this.centre = 1;
       this.specialAbilitiesString += "* Centre" + "\n";


### PR DESCRIPTION
Sofifa recently changed a variable name inside the "Mentality" section:  
it went from "Att. Position" to "Attack position".  

This change completely broke the calculation for "positioning", causing incorrect values for attack and teamwork (both showing 99).  
The fix updates the variable reference to match the new Sofifa naming.
